### PR TITLE
Adding support for optional path

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface Options {
   repo?: string
 
   /**
-   * Path(s) to a file or directory to limit results to specific changes. When no `path` is specified, the entire history of the project id returned.
+   * Path(s) to a file or directory to limit results to specific changes. When no `path` is specified, the entire history of the project is returned.
    */
   path?: string | string[]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,11 @@ export interface Options {
    * @default process.cwd()
    */
   repo?: string
+
+  /**
+   * Path(s) to a file or directory to limit results to specific changes. When no `path` is specified, the entire history of the project id returned.
+   */
+  path?: string | string[]
 }
 
 export interface Commit {

--- a/index.js
+++ b/index.js
@@ -26,5 +26,15 @@ export default async function gitLog (options = {}) {
 
   args.push(options.range || 'HEAD')
 
+  if (options.path) {
+    args.push("--")
+
+    if (Array.isArray(options.path)) {
+      args.push(...options.path)
+    } else {
+      args.push(options.path)
+    }
+  }
+
   return (await execa('git', args, { cwd })).stdout.replace(endRegex, '').split(delim2).map(parseEntry)
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export default async function gitLog (options = {}) {
   args.push(options.range || 'HEAD')
 
   if (options.path) {
-    args.push("--")
+    args.push('--')
 
     if (Array.isArray(options.path)) {
       args.push(...options.path)

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ console.log(commits[0].body)
   - `merges` (`boolean`, optional) - Wether or not to include commits with more than one parent.
   - `range` (`string`, optional) - Include only commits in the specified revision range. When no `range` is specified, it defaults to `'HEAD'` (i.e. the whole history leading to the current commit).
   - `repo` (`string`, optional) - Path to the repository to read the log from. When no `repo` is specified, the current working dirtectory will be used.
+  - `path` (`string | string[]`, optional) - Path to a file or directory to limit results to specific changes. When no `path` is specified, the entire history of the project id returned.
 - returns `Promise<object[]>` - List of commits
   - `subject` (`string`) - Subject of the commit
   - `body` (`string`) - Body of the commit

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ console.log(commits[0].body)
   - `merges` (`boolean`, optional) - Wether or not to include commits with more than one parent.
   - `range` (`string`, optional) - Include only commits in the specified revision range. When no `range` is specified, it defaults to `'HEAD'` (i.e. the whole history leading to the current commit).
   - `repo` (`string`, optional) - Path to the repository to read the log from. When no `repo` is specified, the current working dirtectory will be used.
-  - `path` (`string | string[]`, optional) - Path to a file or directory to limit results to specific changes. When no `path` is specified, the entire history of the project id returned.
+  - `path` (`string | string[]`, optional) - Path to a file or directory to limit results to specific changes. When no `path` is specified, the entire history of the project is returned.
 - returns `Promise<object[]>` - List of commits
   - `subject` (`string`) - Subject of the commit
   - `body` (`string`) - Body of the commit


### PR DESCRIPTION
Added support for the optional file/directory path option:

`git log [<options>] [<revision-range>] [[--] <path...>`

Since `git` supports multiple `path` arguments, you can pass either a string or an array of strings.